### PR TITLE
Remove DockerNamespace

### DIFF
--- a/public/orbs-public-blockchain.md
+++ b/public/orbs-public-blockchain.md
@@ -141,8 +141,7 @@ The content of the `orbs-node.json` should be:
                     },
                     "Config": {
                         "BootstrapMode": true,
-                        "EthereumEndpoint": "<ethereum endpoint url>",
-                        "DockerNamespace":"orbsnetwork"
+                        "EthereumEndpoint": "<ethereum endpoint url>"
                     }
                 }
             }


### PR DESCRIPTION
Since we tagged bootstrap image (management - service) which does not read this config field, no need to specify it.

TBD - if we want to document the new DeploymentDescriptorUrl parameter - where should it be documented - we don't want to draw attention to it. 